### PR TITLE
Add financial planning CLI application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Financial Planning Toolkit
+
+This lightweight command-line application helps you understand how your income is distributed, how long it will take to pay off debts, and where your monthly expenses are going.
+
+## Features
+- Net and gross income comparison with detailed tax and deduction breakdowns.
+- Debt payoff timeline with total interest paid per debt.
+- Monthly recurring expenses summary by category.
+- JSON output for importing results into other tools.
+
+## Getting Started
+1. Create a Python virtual environment and install dependencies (only the standard library is used).
+2. Prepare a JSON profile similar to [`sample_profile.json`](sample_profile.json).
+
+Example profile structure:
+```json
+{
+  "gross_income": 7500,
+  "tax_rate": 0.24,
+  "pre_tax_deductions": {
+    "401k": 400,
+    "HSA": 150
+  },
+  "post_tax_deductions": {
+    "Health Insurance": 300,
+    "Union Dues": 45
+  },
+  "debts": [
+    {
+      "name": "Auto Loan",
+      "principal": 18000,
+      "annual_interest_rate": 0.045,
+      "monthly_payment": 400
+    }
+  ],
+  "expenses": {
+    "Rent": 1800,
+    "Utilities": 250,
+    "Groceries": 600,
+    "Transportation": 220,
+    "Subscriptions": 90
+  }
+}
+```
+
+## Usage
+Run the CLI by pointing it at your profile file:
+
+```bash
+python -m financial_app.cli sample_profile.json
+```
+
+Add `--as-json` to output the full report as JSON instead of a human-readable summary.
+
+```bash
+python -m financial_app.cli sample_profile.json --as-json
+```
+
+## Notes
+- Tax rate should be provided as a decimal (e.g. `0.22` for 22%).
+- Pre-tax deductions reduce the taxable income before calculating taxes.
+- The debt payoff calculation assumes fixed monthly payments and interest compounded monthly.

--- a/financial_app/__init__.py
+++ b/financial_app/__init__.py
@@ -1,0 +1,17 @@
+"""Financial planning toolkit."""
+
+from .calculations import (
+    calculate_debt_payoff,
+    calculate_expense_summary,
+    calculate_net_income,
+    generate_financial_overview,
+)
+from .config import load_profile
+
+__all__ = [
+    "calculate_debt_payoff",
+    "calculate_expense_summary",
+    "calculate_net_income",
+    "generate_financial_overview",
+    "load_profile",
+]

--- a/financial_app/calculations.py
+++ b/financial_app/calculations.py
@@ -1,0 +1,166 @@
+"""Core calculation helpers for the financial planning app."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+
+@dataclass
+class NetIncomeBreakdown:
+    """Detailed view of a net income calculation."""
+
+    gross_income: float
+    taxable_income: float
+    tax_rate: float
+    tax_paid: float
+    pre_tax_deductions: Dict[str, float]
+    post_tax_deductions: Dict[str, float]
+
+    @property
+    def total_deductions(self) -> float:
+        return sum(self.pre_tax_deductions.values()) + sum(
+            self.post_tax_deductions.values()
+        ) + self.tax_paid
+
+    @property
+    def net_income(self) -> float:
+        return self.gross_income - self.total_deductions
+
+
+@dataclass
+class DebtPayoffSummary:
+    """Summary information about a debt payoff schedule."""
+
+    name: str
+    months_to_payoff: int
+    years_to_payoff: float
+    total_interest_paid: float
+    total_amount_paid: float
+
+
+def calculate_net_income(
+    gross_income: float,
+    tax_rate: float,
+    pre_tax_deductions: Optional[Dict[str, float]] = None,
+    post_tax_deductions: Optional[Dict[str, float]] = None,
+) -> NetIncomeBreakdown:
+    """Calculate the net income after all deductions.
+
+    Args:
+        gross_income: Total income before any deductions.
+        tax_rate: Combined marginal tax rate expressed as a decimal (e.g. 0.22 for 22%).
+        pre_tax_deductions: Deductions taken before taxes (e.g. retirement contributions).
+        post_tax_deductions: Deductions taken after taxes (e.g. insurance premiums).
+
+    Returns:
+        A :class:`NetIncomeBreakdown` capturing details of the calculation.
+    """
+
+    pre_tax_deductions = pre_tax_deductions or {}
+    post_tax_deductions = post_tax_deductions or {}
+
+    taxable_income = max(gross_income - sum(pre_tax_deductions.values()), 0.0)
+    tax_paid = taxable_income * tax_rate
+
+    return NetIncomeBreakdown(
+        gross_income=gross_income,
+        taxable_income=taxable_income,
+        tax_rate=tax_rate,
+        tax_paid=tax_paid,
+        pre_tax_deductions=dict(sorted(pre_tax_deductions.items())),
+        post_tax_deductions=dict(sorted(post_tax_deductions.items())),
+    )
+
+
+def _iterate_debt_payoff(
+    principal: float, annual_interest_rate: float, monthly_payment: float
+) -> Tuple[int, float]:
+    """Iteratively determine the number of months and interest paid to clear a debt."""
+
+    if principal <= 0:
+        return 0, 0.0
+
+    monthly_rate = annual_interest_rate / 12
+    if monthly_rate < 0:
+        raise ValueError("Interest rate must not be negative.")
+
+    if monthly_payment <= principal * monthly_rate:
+        raise ValueError(
+            "Monthly payment is too low to cover even the interest. Increase the payment."
+        )
+
+    months = 0
+    total_interest = 0.0
+    balance = principal
+
+    while balance > 0:
+        interest = balance * monthly_rate
+        principal_payment = monthly_payment - interest
+        balance = max(balance - principal_payment, 0.0)
+        total_interest += interest
+        months += 1
+
+    return months, total_interest
+
+
+def calculate_debt_payoff(
+    name: str,
+    principal: float,
+    annual_interest_rate: float,
+    monthly_payment: float,
+) -> DebtPayoffSummary:
+    """Compute payoff time and interest for a given debt."""
+
+    months, total_interest = _iterate_debt_payoff(
+        principal, annual_interest_rate, monthly_payment
+    )
+    total_paid = principal + total_interest
+
+    return DebtPayoffSummary(
+        name=name,
+        months_to_payoff=months,
+        years_to_payoff=months / 12 if months else 0.0,
+        total_interest_paid=total_interest,
+        total_amount_paid=total_paid,
+    )
+
+
+def calculate_expense_summary(expenses: Dict[str, float]) -> Dict[str, float]:
+    """Summarise recurring expenses."""
+
+    total = sum(expenses.values())
+    return {
+        "total": total,
+        "by_category": dict(sorted(expenses.items())),
+    }
+
+
+def generate_financial_overview(profile: Dict) -> Dict:
+    """Generate a comprehensive report for the provided financial profile."""
+
+    net_income = calculate_net_income(
+        profile.get("gross_income", 0.0),
+        profile.get("tax_rate", 0.0),
+        profile.get("pre_tax_deductions", {}),
+        profile.get("post_tax_deductions", {}),
+    )
+
+    debts = profile.get("debts", [])
+    debt_summaries: List[DebtPayoffSummary] = []
+    for debt in debts:
+        debt_summaries.append(
+            calculate_debt_payoff(
+                name=debt.get("name", "Debt"),
+                principal=debt.get("principal", 0.0),
+                annual_interest_rate=debt.get("annual_interest_rate", 0.0),
+                monthly_payment=debt.get("monthly_payment", 0.0),
+            )
+        )
+
+    expenses_summary = calculate_expense_summary(profile.get("expenses", {}))
+
+    return {
+        "net_income": net_income,
+        "debts": debt_summaries,
+        "expenses": expenses_summary,
+    }

--- a/financial_app/cli.py
+++ b/financial_app/cli.py
@@ -1,0 +1,101 @@
+"""Command-line interface for the financial planning app."""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from typing import Any, Dict
+
+from .calculations import DebtPayoffSummary, NetIncomeBreakdown, generate_financial_overview
+from .config import load_profile
+
+
+def _format_currency(amount: float) -> str:
+    return f"${amount:,.2f}"
+
+
+def _render_net_income(net: NetIncomeBreakdown) -> str:
+    lines = ["NET INCOME"]
+    lines.append(f"Gross income: {_format_currency(net.gross_income)}")
+    lines.append(f"Taxable income: {_format_currency(net.taxable_income)}")
+    lines.append(f"Tax rate: {net.tax_rate:.2%}")
+    lines.append(f"Tax paid: {_format_currency(net.tax_paid)}")
+
+    if net.pre_tax_deductions:
+        lines.append("Pre-tax deductions:")
+        for name, amount in net.pre_tax_deductions.items():
+            lines.append(f"  - {name}: {_format_currency(amount)}")
+
+    if net.post_tax_deductions:
+        lines.append("Post-tax deductions:")
+        for name, amount in net.post_tax_deductions.items():
+            lines.append(f"  - {name}: {_format_currency(amount)}")
+
+    lines.append(f"Total deductions: {_format_currency(net.total_deductions)}")
+    lines.append(f"Net income: {_format_currency(net.net_income)}")
+    return "\n".join(lines)
+
+
+def _render_debt(debt: DebtPayoffSummary) -> str:
+    lines = [f"Debt: {debt.name}"]
+    lines.append(f"  Months to payoff: {debt.months_to_payoff}")
+    lines.append(f"  Years to payoff: {debt.years_to_payoff:.2f}")
+    lines.append(f"  Total interest paid: {_format_currency(debt.total_interest_paid)}")
+    lines.append(f"  Total paid: {_format_currency(debt.total_amount_paid)}")
+    return "\n".join(lines)
+
+
+def _render_expenses(expenses: Dict[str, Any]) -> str:
+    lines = ["EXPENSES"]
+    lines.append(f"Total monthly expenses: {_format_currency(expenses['total'])}")
+    if expenses["by_category"]:
+        lines.append("By category:")
+        for name, amount in expenses["by_category"].items():
+            lines.append(f"  - {name}: {_format_currency(amount)}")
+    return "\n".join(lines)
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Financial planning toolkit")
+    parser.add_argument(
+        "profile",
+        type=str,
+        help="Path to a JSON profile describing income, debts, and expenses.",
+    )
+    parser.add_argument(
+        "--as-json",
+        action="store_true",
+        help="Output the report as JSON instead of a formatted summary.",
+    )
+    return parser
+
+
+def main(argv: Any = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    profile = load_profile(args.profile)
+    overview = generate_financial_overview(profile)
+
+    if args.as_json:
+        serialisable = {
+            "net_income": asdict(overview["net_income"]),
+            "debts": [asdict(debt) for debt in overview["debts"]],
+            "expenses": overview["expenses"],
+        }
+        print(json.dumps(serialisable, indent=2))
+    else:
+        print(_render_net_income(overview["net_income"]))
+        if overview["debts"]:
+            print("\nDEBTS")
+            for debt in overview["debts"]:
+                print(_render_debt(debt))
+        else:
+            print("\nDEBTS\nNo debts provided.")
+        print("\n" + _render_expenses(overview["expenses"]))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/financial_app/config.py
+++ b/financial_app/config.py
@@ -1,0 +1,21 @@
+"""Helpers for loading configuration for the financial planning app."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_profile(path: str) -> Dict[str, Any]:
+    """Load a JSON profile from disk.
+
+    The file must contain valid JSON mapping describing the income, debt,
+    and expense information required by :func:`financial_app.generate_financial_overview`.
+    """
+
+    profile_path = Path(path)
+    if not profile_path.exists():
+        raise FileNotFoundError(f"Profile file not found: {path}")
+
+    with profile_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)

--- a/sample_profile.json
+++ b/sample_profile.json
@@ -1,0 +1,33 @@
+{
+  "gross_income": 7500,
+  "tax_rate": 0.24,
+  "pre_tax_deductions": {
+    "401k": 400,
+    "HSA": 150
+  },
+  "post_tax_deductions": {
+    "Health Insurance": 300,
+    "Union Dues": 45
+  },
+  "debts": [
+    {
+      "name": "Auto Loan",
+      "principal": 18000,
+      "annual_interest_rate": 0.045,
+      "monthly_payment": 400
+    },
+    {
+      "name": "Student Loan",
+      "principal": 32000,
+      "annual_interest_rate": 0.055,
+      "monthly_payment": 500
+    }
+  ],
+  "expenses": {
+    "Rent": 1800,
+    "Utilities": 250,
+    "Groceries": 600,
+    "Transportation": 220,
+    "Subscriptions": 90
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -1,0 +1,61 @@
+from financial_app.calculations import (
+    calculate_debt_payoff,
+    calculate_expense_summary,
+    calculate_net_income,
+    generate_financial_overview,
+)
+
+
+def test_calculate_net_income_handles_pre_and_post_tax_deductions():
+    breakdown = calculate_net_income(
+        gross_income=6000,
+        tax_rate=0.2,
+        pre_tax_deductions={"401k": 300},
+        post_tax_deductions={"Insurance": 200},
+    )
+
+    assert round(breakdown.taxable_income, 2) == 5700.0
+    assert round(breakdown.tax_paid, 2) == 1140.0
+    assert round(breakdown.net_income, 2) == 4360.0
+
+
+def test_calculate_debt_payoff_returns_total_interest():
+    summary = calculate_debt_payoff(
+        name="Loan",
+        principal=1000,
+        annual_interest_rate=0.12,
+        monthly_payment=100,
+    )
+
+    assert summary.months_to_payoff > 0
+    assert summary.total_interest_paid > 0
+    assert summary.total_amount_paid == summary.total_interest_paid + 1000
+
+
+def test_calculate_expense_summary_orders_categories():
+    summary = calculate_expense_summary({"b": 2, "a": 1})
+    assert summary["total"] == 3
+    assert list(summary["by_category"].keys()) == ["a", "b"]
+
+
+def test_generate_financial_overview_combines_sections():
+    profile = {
+        "gross_income": 5000,
+        "tax_rate": 0.22,
+        "pre_tax_deductions": {"401k": 200},
+        "post_tax_deductions": {"Insurance": 150},
+        "debts": [
+            {
+                "name": "Car",
+                "principal": 10000,
+                "annual_interest_rate": 0.05,
+                "monthly_payment": 300,
+            }
+        ],
+        "expenses": {"Rent": 1500},
+    }
+
+    overview = generate_financial_overview(profile)
+    assert overview["net_income"].net_income > 0
+    assert overview["debts"][0].name == "Car"
+    assert overview["expenses"]["total"] == 1500


### PR DESCRIPTION
## Summary
- add financial calculations for income breakdowns, debt payoff timelines, and expense summaries
- provide a command-line interface that reads a JSON profile and renders formatted or JSON reports
- document usage with a sample profile, README, and regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69091f66e1c883259e4a8d9d7d2d016e